### PR TITLE
convert_util: convert_opts now uses sockaddr_in6

### DIFF
--- a/convert_client.c
+++ b/convert_client.c
@@ -181,8 +181,8 @@ _redirect_connect_tlv(uint8_t *buf, size_t buf_len, struct sockaddr *addr)
 		struct sockaddr_in *in = (struct sockaddr_in *)addr;
 
 		/* already in network bytes */
-		_to_v4mapped(in->sin_addr.s_addr, &opts.remote_addr);
-		opts.remote_port = in->sin_port;
+		_to_v4mapped(in->sin_addr.s_addr, &opts.remote_addr.sin6_addr);
+		opts.remote_addr.sin6_port = in->sin_port;
 		break;
 	}
 	case AF_INET6: {
@@ -191,7 +191,6 @@ _redirect_connect_tlv(uint8_t *buf, size_t buf_len, struct sockaddr *addr)
 		/* already in network bytes */
 		memcpy(&opts.remote_addr, &in6->sin6_addr,
 		       sizeof(opts.remote_addr));
-		opts.remote_port = in6->sin6_port;
 		break;
 	}
 	default:

--- a/convert_util.c
+++ b/convert_util.c
@@ -109,9 +109,16 @@ convert_parse_tlvs(const uint8_t *buff, size_t buff_len,
 			    CONVERT_ALIGN(sizeof(*conv_connect)))
 				return -1;
 
-			opts->flags		|= CONVERT_F_CONNECT;
-			opts->remote_addr	= conv_connect->remote_addr;
-			opts->remote_port	= conv_connect->remote_port;
+			opts->flags |= CONVERT_F_CONNECT;
+			/* conv_connect comes from the network, and thus is in
+			 * network byte order. The sin6_port and sin6_addr
+			 * members of remote_addr shall also be in network byte
+			 * order.
+			 */
+			opts->remote_addr.sin6_addr =
+			        conv_connect->remote_addr;
+			opts->remote_addr.sin6_port =
+			        conv_connect->remote_port;
 
 			break;
 		}
@@ -144,8 +151,8 @@ _convert_write_tlv_connect(uint8_t *buff, size_t buff_len,
 	if (buff_len < length)
 		return -1;
 
-	conv_connect->remote_addr	= opts->remote_addr;
-	conv_connect->remote_port	= opts->remote_port;
+	conv_connect->remote_addr	= opts->remote_addr.sin6_addr;
+	conv_connect->remote_port	= opts->remote_addr.sin6_port;
 
 	return length;
 }

--- a/convert_util.h
+++ b/convert_util.h
@@ -62,18 +62,19 @@ enum {
 };
 
 struct convert_opts {
-	uint8_t		flags;
+	uint8_t			flags;
 
-	/* if CONVERT_F_CONNECT is set in flags */
-	struct in6_addr remote_addr;
-	uint16_t	remote_port;
+	/* if CONVERT_F_CONNECT is set in flags
+	 * The sin_port and sin_addr members shall be in network byte order.
+	 */
+	struct sockaddr_in6	remote_addr;
 
 	/* if CONVERT_F_ERROR is set in flags */
-	uint8_t		error_code;
+	uint8_t			error_code;
 
 	/* if CONVERT_F_EXTENDED_TCP_HDR is set in flags */
-	uint8_t *	tcp_options;
-	size_t		tcp_options_len;
+	uint8_t *		tcp_options;
+	size_t			tcp_options_len;
 
 	/* TODO extend to support more TLVs. */
 };

--- a/tests/check_convert_util.c
+++ b/tests/check_convert_util.c
@@ -143,12 +143,12 @@ START_TEST(test_convert_parse_tlvs_connect){
 	ret = convert_parse_tlvs(buff, buff_len, &opts);
 	ck_assert_msg(ret == 0, "Should parse valid Convert Connect TLV");
 	ck_assert_msg(opts.flags & CONVERT_F_CONNECT, "Should set CONNECT flag");
-	ck_assert_msg(opts.remote_port == connect->remote_port,
+	ck_assert_msg(opts.remote_addr.sin6_port == connect->remote_port,
 	              "Should parse remote_port");
 	unsigned int i = 0;
-	for (i = 0; i < sizeof(opts.remote_addr.s6_addr); ++i)
+	for (i = 0; i < sizeof(opts.remote_addr.sin6_addr.s6_addr); ++i)
 		ck_assert_msg(
-		        opts.remote_addr.s6_addr[i] ==
+		        opts.remote_addr.sin6_addr.s6_addr[i] ==
 		        connect->remote_addr.s6_addr[i],
 		        "Should parse remote_addr");
 


### PR DESCRIPTION
Address and port shall always be in network-byte order.

Signed-off-by: Gregory Vander Schueren <gregory.vanderschueren@tessares.net>
Change-Id: If3010e29a43af645d1c57ffa4cca15510614558f