### PR TITLE
Support for parsing Convert Extended TCP Header

### DIFF
--- a/convert_util.h
+++ b/convert_util.h
@@ -79,12 +79,17 @@ struct convert_opts {
 	/* TODO extend to support more TLVs. */
 };
 
+void
+convert_free_opts(struct convert_opts *opts);
+
 int
 convert_parse_header(const uint8_t *buff, size_t buff_len, size_t *tlvs_length);
 
-int
-convert_parse_tlvs(const uint8_t *buff, size_t buff_len,
-                   struct convert_opts *opts);
+/* Returns a pointer to struct convert_opts, which must be freed by the caller
+ * using convert_free_opts(). Returns NULL upon failure.
+ */
+struct convert_opts *
+convert_parse_tlvs(const uint8_t *buff, size_t buff_len);
 
 ssize_t
 convert_write(uint8_t *buff, size_t buff_len, const struct convert_opts *opts);


### PR DESCRIPTION
This will be useful when we add support for the Convert Extended TCP
Header in convert_parse_tlvs. In this case, we will need to return a
variable length array of TCP options.

Signed-off-by: Gregory Vander Schueren <gregory.vanderschueren@tessares.net>
Change-Id: I2b193d8e69317796b5d509807cec830e1fa984f2