### PR TITLE
Readme: update

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The library supports IPv6 as well.
 
 Currently tested with `curl` & `wget` on both Centos 7 and Ubuntu {16,18,19}.
 
+The library is known to *not* work on Ubuntu 20 due to incompatibilities between `lib_syscall_intercept` and `libc 20.30-1`. This issue is tracked [here](https://github.com/pmem/syscall_intercept/issues/97).
+
 ### Contributing
 
 Code contributions are more than welcome.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # libconvert [![Build Status](https://travis-ci.com/Tessares/libconvert.svg?branch=master)](https://travis-ci.com/Tessares/libconvert)
 
-An `LD_PRELOAD` library that turns an existing client, using TCP sockets, into
-a Convert client. See the IETF draft [draft-ietf-tcpm-converters-05](https://datatracker.ietf.org/doc/draft-ietf-tcpm-converters) for more information.
+Libraries to work with 0-RTT TCP Convert Protocol ([RFC 8803](https://datatracker.ietf.org/doc/draft-ietf-tcpm-converters)).
+* `libconvert_util`: A library to parse and write Convert messages.
+* `libconvert_client`: An `LD_PRELOAD` library that turns an existing client, using TCP sockets, into a Convert client.
 
-This is work in progress. The `LD_PRELOAD` client and the underlying library currently only support the Connect TLV and the Error TLV. This repository does not yet include a server-side Transport Converter.
+This is work in progress. The `libconvert_util` library currently only supports the Connect TLV and the Error TLV. This repository does not yet include a server-side Transport Converter.
 
 Future work:
 * Sample server-side Transport Converter
@@ -16,14 +17,14 @@ Future work:
 * Requires Linux >= 4.5 (leverages the TCP Fast Open infrastructure).
 * Configure `$ sysctl -w net.ipv4.tcp_fastopen=5` to enable sending data in the opening SYN, regardless of cookie availability.
 
-### Build & usage
+### Build
 
 Fetch the Git submodules:
 ```
 $ git submodule init && git submodule update
 ```
 
-The easiest way to build and run the tests is with the provided Dockerfile (which contains all deps):
+The easiest way to build both libraries and run the tests is with the provided Dockerfile (which contains all deps):
 ```
 $ docker build -t tessares.net/libconvert .
 $ docker run --cap-add=NET_ADMIN --sysctl net.ipv4.tcp_fastopen=5 -v $PWD:/lc -t tessares.net/libconvert /bin/bash -c "mkdir -p /lc/build && cd /lc/build && cmake .. && make && make test"
@@ -34,12 +35,22 @@ Otherwise, assuming all deps are installed, build and run the tests with CMake a
 $ mkdir -p build && cd build && cmake .. && make && make test
 ```
 
-Usage (assuming a Transport Converter listening at 192.0.2.1:1234):
+### Usage & dependencies of `libconvert_client`
+
+#### Runtime dependencies
+
+ * libcapstone -- the disassembly engine used by used under the hood by `lib_syscall_intercept`.
+
+#### Usage
+
+To use the `libconvert_client` lib (assuming a Transport Converter listening at 192.0.2.1:1234):
 ```
 $ CONVERT_ADDR=192.0.2.1 CONVERT_PORT=1234 LD_LIBRARY_PATH=$PWD/build LD_PRELOAD=libconvert_client.so curl https://www.tessares.net
 ```
 
-Currently tested with `curl` & `wget` on both Centos 7 and Ubuntu {16,18,19}
+The library supports IPv6 as well.
+
+Currently tested with `curl` & `wget` on both Centos 7 and Ubuntu {16,18,19}.
 
 ### Contributing
 
@@ -50,9 +61,6 @@ Upon change, please run `uncrustify` (0.68) and validate that `cppcheck` is stil
 $ uncrustify -c uncrustify.cfg -l C --replace --no-backup convert*.{h,c}
 $ cppcheck -I/usr/include -q --language=c --std=c99 --enable=warning,style,performance,portability -j "$(nproc)" --suppress=unusedStructMember ./convert*.{h,c}
 ```
-
-To contribute to the Convert protocol, see this [Github repository](https://github.com/obonaventure/draft-tcp-converters), which tracks the evolution of the 0-RTT TCP Converter
-Internet draft.
 
 To ease troubleshooting, download the 0-RTT TCP Convert [Wireshark dissector plugin](https://github.com/Tessares/convert-wireshark-dissector).
 


### PR DESCRIPTION
- Draft is now an RFC.
- Explain there are 2 libs in this repo.
- List runtime deps of libconvert_client.
- Does not work on Ubuntu 20.

Signed-off-by: Gregory Vander Schueren <gregory.vanderschueren@tessares.net>