### PR TITLE
tests: add IPv6 converter tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,14 +26,16 @@ set(TEST_WRAPPER "${PROJECT_SOURCE_DIR}/tests/test-wrapper")
 
 foreach(TEST_CMD "curl" "wget")
     foreach(TEST_TYPE "test_ok" "test_error")
-        set (test_name "${TEST_CMD}-${TEST_TYPE}")
+        foreach(IP_VERSION "4" "6")
+            set (test_name "${TEST_CMD}-${TEST_TYPE}-IPv${IP_VERSION}")
 
-        add_test(NAME "${test_name}"
-                COMMAND ${TEST_WRAPPER} "${TEST_TYPE}.py")
-        set_tests_properties("${test_name}" PROPERTIES
-            ENVIRONMENT
-            "SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR};BUILD_DIR=${PROJECT_BINARY_DIR};TOP_SOURCE_DIR=${PROJECT_SOURCE_DIR};TEST_CMD=${TEST_CMD}"
-           TIMEOUT 5)
+            add_test(NAME "${test_name}"
+                COMMAND ${TEST_WRAPPER} "${TEST_TYPE}.py" "${IP_VERSION}")
+            set_tests_properties("${test_name}" PROPERTIES
+                ENVIRONMENT
+                "SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR};BUILD_DIR=${PROJECT_BINARY_DIR};TOP_SOURCE_DIR=${PROJECT_SOURCE_DIR};TEST_CMD=${TEST_CMD}"
+                TIMEOUT 5)
+        endforeach()
     endforeach()
 endforeach()
 

--- a/tests/test-wrapper
+++ b/tests/test-wrapper
@@ -8,6 +8,7 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 CONVERT_SCRIPT="$1"
+IP_VERSION="$2"
 
 export TEST_CONVERT_LOG=convert.log
 export TEST_OUTPUT_LOG=output.log
@@ -19,7 +20,12 @@ SCAPY_PID=
 RETURN_CODE=1
 
 test_step() {
-    PYTHONPATH="${PYTHONPATH}:${TOP_SOURCE_DIR}/scapy" "${SOURCE_DIR}/${CONVERT_SCRIPT}" "$1"
+    PYTHONPATH="${PYTHONPATH}:${TOP_SOURCE_DIR}/scapy" "${SOURCE_DIR}/${CONVERT_SCRIPT}" "$1" "${IP_VERSION}"
+}
+
+iptables_both() {
+    iptables "${@}"
+    ip6tables "${@}"
 }
 
 cleanup() {
@@ -29,7 +35,7 @@ cleanup() {
     set +e
 
     # remove firewall rule
-    iptables -D INPUT -i lo -p tcp --dport 1234 -j DROP
+    iptables_both -D INPUT -i lo -p tcp --dport 1234 -j DROP
 
     # kill scapy server if still runing
     [ -n "${SCAPY_PID}" ] && kill "${SCAPY_PID}" 2> /dev/null
@@ -47,10 +53,11 @@ cleanup() {
 trap cleanup EXIT
 
 # prevent the stack to send RST for packets handled by Scapy.
-iptables -I INPUT -i lo -p tcp --dport 1234 -j DROP
+iptables_both -I INPUT -i lo -p tcp --dport 1234 -j DROP
 
 # make sure that TFO cache is disabled :)
-ip tcp_metrics flush
+ip -4 tcp_metrics flush
+ip -6 tcp_metrics flush
 
 # run the scapy server
 test_step server > "${TEST_CONVERT_MOCK_LOG}" 2>&1 &
@@ -58,9 +65,14 @@ SCAPY_PID=$!
 
 sleep 1
 
+if [[ ${IP_VERSION} == '6' ]]; then
+	CONVERT_ADDR="::1/128"
+else
+	CONVERT_ADDR="127.0.0.1"
+fi
 
 COMMAND=$(test_step run_cmd)
-CONVERT_LOG=${TEST_CONVERT_LOG} CONVERT_ADDR=127.0.0.1 LD_PRELOAD="../libconvert_client.so" ${COMMAND} > ${TEST_OUTPUT_LOG} 2>&1 || true
+CONVERT_LOG=${TEST_CONVERT_LOG} CONVERT_ADDR=${CONVERT_ADDR} LD_PRELOAD="../libconvert_client.so" ${COMMAND} > ${TEST_OUTPUT_LOG} 2>&1 || true
 
 ret=$(test_step validate 2>&1 | tee ${TEST_VALIDATE_LOG})
 [ "${ret}" == "" ] && RETURN_CODE=0

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -5,13 +5,13 @@ from test_lib import *
 
 
 class TestError(TestInstance):
-    def run(self):
+    def server(self):
         converter = Convert(tlvs=[ConvertTLV_Error(error_code=1)])
         print(converter.build())
 
         class MockConverterError(MockConverter):
             actions = [RecvSyn(), SendSynAck(payload=converter.build()), Wait(1), SendPkt(flags='R')]
-        MockConverterError()
+        MockConverterError(address=self.converter_adress())
 
     def validate(self):
         self.assert_error_result()

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -3,17 +3,21 @@ import os
 
 
 class curl:
-    COMMAND = "curl -4 http://www.tessares.net/ -s -S -o -"
+    def print_cmd(ip_version):
+        return "curl -%s http://www.tessares.net/ -s -S -o -" % ip_version
+
     ERROR_MATCH = "Connection reset by peer"
 
 
 class wget:
-    COMMAND = "wget -4 http://www.tessares.net/ -t1 -O -"
+    def print_cmd(ip_version):
+        return "wget -%s http://www.tessares.net/ -t1 -O -" % ip_version
+
     ERROR_MATCH = "failed: Connection refused."
 
 
 class TestInstance:
-    def run(self):
+    def server(self):
         raise NotImplemented()
 
     def validate(self):
@@ -25,7 +29,7 @@ class TestInstance:
 
     def run_cmd(self):
         klass = self._cmd()
-        print(klass.COMMAND)
+        print(klass.print_cmd(self.ip_version))
 
     def _get_result(self):
         with open(os.environ["TEST_OUTPUT_LOG"]) as f:
@@ -45,13 +49,21 @@ class TestInstance:
     def assert_log_contains(self, log):
         assert log in self._get_log(), "Couldn't find '{}' in log".format(log)
 
+    def converter_adress(self):
+        if self.ip_version == '6':
+            return '::1/128'
+        else:
+            return '127.0.0.1'
+
     def __init__(self):
         if len(sys.argv) < 2:
             raise Exception("don't run this manually")
 
         action = sys.argv[1]
+        self.ip_version = sys.argv[2]
+
         {
-            'server': lambda: self.run(),
+            'server': lambda: self.server(),
             'validate': lambda: self.validate(),
             'run_cmd': lambda: self.run_cmd(),
         }[action]()

--- a/tests/test_ok.py
+++ b/tests/test_ok.py
@@ -5,11 +5,11 @@ from test_lib import *
 
 
 class TestOK(TestInstance):
-    def run(self):
+    def server(self):
         class MockConverterOK(MockConverter):
             actions = [RecvSyn(), SendSynAck(payload=Convert().build()), RecvHTTPGet(
             ), SendHTTPResp("HELLO, WORLD!"), SendPkt(flags='RA')]
-        MockConverterOK()
+        MockConverterOK(address=self.converter_adress())
 
     def validate(self):
         self.assert_result("HELLO, WORLD!")


### PR DESCRIPTION
Adding test with converter reachable over IPv6.

Unfortunately these are currently failing as the Docker doesn't have IPv6 enabled.
(getaddrinfo returns: "unable to resolve '::1/128'").

Apparently we can't enable IPv6 in the Docker without changing the config of the Docker daemon.
And it seems from Travis doc that their Docker does not support IPv6 (https://docs.travis-ci.com/user/reference/overview/)
So I will probably abandon this patch... 

Signed-off-by: Gregory Vander Schueren <gregory.vanderschueren@tessares.net>