### PR TITLE
convert_client: fix connect tlv for IPv6

### DIFF
--- a/convert_client.c
+++ b/convert_client.c
@@ -188,8 +188,7 @@ _redirect_connect_tlv(uint8_t *buf, size_t buf_len, struct sockaddr *addr)
 		struct sockaddr_in6 *in6 = (struct sockaddr_in6 *)addr;
 
 		/* already in network bytes */
-		memcpy(&opts.remote_addr, &in6->sin6_addr,
-		       sizeof(opts.remote_addr));
+		memcpy(&opts.remote_addr, in6, sizeof(opts.remote_addr));
 		break;
 	}
 	default:


### PR DESCRIPTION
IPv6 has never worked as we were copying a "struct sin6_addr" into
a "struct sockaddr_in6", thus effectively discarding the leading
bytes of the end-server IPv6 address.

Signed-off-by: Gregory Vander Schueren <gregory.vanderschueren@tessares.net>