### PR TITLE
libconvert: send cookie TLV on client side

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ add_test(NAME check_convert_util
 set(TEST_WRAPPER "${PROJECT_SOURCE_DIR}/tests/test-wrapper")
 
 foreach(TEST_CMD "curl" "wget")
-    foreach(TEST_TYPE "test_ok" "test_error")
+    foreach(TEST_TYPE "test_ok" "test_error" "test_cookie_ok" "test_cookie_error")
         set (test_name "${TEST_CMD}-${TEST_TYPE}")
 
         add_test(NAME "${test_name}"

--- a/tests/check_convert_util.c
+++ b/tests/check_convert_util.c
@@ -279,7 +279,7 @@ START_TEST (test_convert_parse_tlvs_cookie) {
 
 	for (i = 0; i < cookie_len; ++i)
 		ck_assert_msg(opts->cookie_data[i] == cookie->opaque[i],
-		              "Should return exact copy TCP options");
+		              "Should return exact cookie value");
 
 	convert_free_opts(opts);
 	free(buff);

--- a/tests/test-wrapper
+++ b/tests/test-wrapper
@@ -13,6 +13,7 @@ export TEST_CONVERT_LOG=convert.log
 export TEST_OUTPUT_LOG=output.log
 export TEST_CONVERT_MOCK_LOG=convert_mock.log
 export TEST_VALIDATE_LOG=validate.log
+export TEST_CONVERT_COOKIE="cookie"
 
 SCAPY_PID=
 
@@ -60,7 +61,11 @@ sleep 1
 
 
 COMMAND=$(test_step run_cmd)
-CONVERT_LOG=${TEST_CONVERT_LOG} CONVERT_ADDR=127.0.0.1 LD_PRELOAD="../libconvert_client.so" ${COMMAND} > ${TEST_OUTPUT_LOG} 2>&1 || true
+CONVERT_LOG=${TEST_CONVERT_LOG} \
+    CONVERT_ADDR=127.0.0.1 \
+    CONVERT_COOKIE=${TEST_CONVERT_COOKIE} \
+    LD_PRELOAD="../libconvert_client.so" \
+        ${COMMAND} > ${TEST_OUTPUT_LOG} 2>&1 || true
 
 ret=$(test_step validate 2>&1 | tee ${TEST_VALIDATE_LOG})
 [ "${ret}" == "" ] && RETURN_CODE=0

--- a/tests/test_cookie_error.py
+++ b/tests/test_cookie_error.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from converter_mock import *
+from test_lib import *
+
+
+class TestCookieError(TestInstance):
+    def run(self):
+        converter = Convert(tlvs=[ConvertTLV_Error(error_code=3)])
+        print(converter.build())
+        cookie = self.get_cookie()
+
+        class MockConverterCookieError(MockConverter):
+            actions = [RecvSyn(), SendSynAckCheckCookie(converter.build(), cookie), Wait(1), SendPkt(flags='R')]
+        MockConverterCookieError()
+
+    def validate(self):
+        self.assert_log_contains("received TLV error: 3")
+
+
+TestCookieError()

--- a/tests/test_cookie_ok.py
+++ b/tests/test_cookie_ok.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+from converter_mock import *
+from test_lib import *
+
+
+class TestCookieOK(TestInstance):
+    def run(self):
+        cookie = self.get_cookie()
+        class MockConverterCookieOK(MockConverter):
+            actions = [RecvSyn(), SendSynAckCheckCookie(Convert().build(), cookie), RecvHTTPGet(
+            ), SendHTTPResp("HELLO, WORLD!"), SendPkt(flags='RA')]
+        MockConverterCookieOK()
+
+    def validate(self):
+        self.assert_result("HELLO, WORLD!")
+
+
+TestCookieOK()

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -35,6 +35,9 @@ class TestInstance:
         with open(os.environ["TEST_CONVERT_LOG"]) as f:
             return f.read()
 
+    def get_cookie(self):
+        return os.environ["TEST_CONVERT_COOKIE"]
+
     def assert_result(self, result):
         assert result in self._get_result(), "Couldn't find '{}' in output".format(result)
 


### PR DESCRIPTION
It is now possible to send a cookie TLV from the client using libconvert.
New tests have been added to check that the expected Cookie message is
sent and the Cookie TLV error is properly received and understood.

Signed-off-by: Pol Nicolaï <pol.nicolai@tessares.net>